### PR TITLE
Unify Tournament types

### DIFF
--- a/DefaultConfiguration.toml
+++ b/DefaultConfiguration.toml
@@ -26,7 +26,7 @@ SIZE = 32
 
 [GameSettings]
 [PlayerSettings]
-MODELS_DIR = "../CatanLearning.jl/models"
+MODELS_DIR = "./models"
 MODELS = ["decision", "public"]
 #MODEL = "./models/model.jls"
 #PUBLIC_MODEL = "./models/public_model.jls"

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -2,24 +2,36 @@ using MLJ
 import Catan: ChosenAction
 import Base: show
 
-struct Tournament
+abstract type AbstractTournament
+end
+
+generate_tournament_id()::Int = rand(range(1,100_000))
+
+struct TournamentConfig
     games_per_map::Int
     maps_per_epoch::Int
     epochs::Int
-    mutation_rule::Symbol
+    generate_random_maps::Bool
     unique_id::Int
+    path::String
 end
 
-function Tournament(configs::Dict, mutation_rule::Symbol) 
-    @debug "$(configs["Tournament"]) $mutation_rule"
-    id = rand(range(1,100_000))
-    Tournament(configs["Tournament"]["GAMES_PER_MAP"], configs["Tournament"]["MAPS_PER_EPOCH"], configs["Tournament"]["NUM_EPOCHS"], mutation_rule, id)
+struct Tournament <: AbstractTournament
+    configs::TournamentConfig
+    #Tournament(configs::Dict) = Tournament(TournamentConfig(configs["Tournament"]))
 end
 
-function Tournament(configs::Dict) 
-    @debug "$(configs["Tournament"]) $mutation_rule"
-    id = rand(range(1,100_000))
-    Tournament(configs["Tournament"]["GAMES_PER_MAP"], configs["Tournament"]["MAPS_PER_EPOCH"], configs["Tournament"]["NUM_EPOCHS"], :noop, id)
+struct MutatingTournament <: AbstractTournament
+    configs::TournamentConfig
+    mutation_rule::Symbol
+    #MutatingTournament(configs::Dict) = MutatingTournament(TournamentConfig(configs["Tournament"]))
+end
+
+struct AsyncTournament <: AbstractTournament
+    configs::TournamentConfig
+    channels::Dict{Symbol, Channel}
+    #AsyncTournament(configs::Dict) = AsyncTournament(TournamentConfig(configs["Tournament"]),
+    #channels = Catan.read_channels_from_config(configs))
 end
 
 struct StateValueContainer

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -18,17 +18,22 @@ end
 
 struct Tournament <: AbstractTournament
     configs::TournamentConfig
+    teams::AbstractVector{Symbol}
+    winners::Dict{Union{Symbol, Nothing}, Int}
     #Tournament(configs::Dict) = Tournament(TournamentConfig(configs["Tournament"]))
 end
 
 struct MutatingTournament <: AbstractTournament
     configs::TournamentConfig
+    teams::AbstractVector{Symbol}
+    winners::Dict{Union{Symbol, Nothing}, Int}
     mutation_rule::Symbol
     #MutatingTournament(configs::Dict) = MutatingTournament(TournamentConfig(configs["Tournament"]))
 end
 
 struct AsyncTournament <: AbstractTournament
     configs::TournamentConfig
+    teams::AbstractVector{Symbol}
     channels::Dict{Symbol, Channel}
     #AsyncTournament(configs::Dict) = AsyncTournament(TournamentConfig(configs["Tournament"]),
     #channels = Catan.read_channels_from_config(configs))

--- a/src/tournaments.jl
+++ b/src/tournaments.jl
@@ -60,26 +60,15 @@ function do_tournament_one_epoch(tourney::AbstractTournament, configs; create_pl
             do_tournament_one_map!(tourney, configs, j, map_str; create_players = create_players)
         end
     end
-    # TODO move order_winners to a finalize_epoch method
     return finalize_epoch(tourney)
 end
 
-function _deprecated_do_tournament_one_epoch(tourney::AsyncTournament, configs; create_players = Catan.create_players)
-    for j=1:tourney.configs.maps_per_epoch
-        @info "map $j / $(tourney.configs.maps_per_epoch)"
-        do_tournament_one_map!(tourney, configs, map_str; create_players = create_players)
-
-        #TODO better to control this with yield here or just implicitly with the Channel buffer size?
-        #yield()
-    end
-end
-
-function do_tournament_one_map!(tourney::AbstractTournament, configs, map_num::Integer; create_players = Catan.create_players)
+function do_tournament_one_map!(tourney::Tournament, configs, map_num::Integer; create_players = Catan.create_players)
     map = Catan.generate_random_map()
     do_tournament_one_map!(tourney, configs, map_num, map; create_players)
 end
 
-function do_tournament_one_map!(tourney::AbstractTournament, configs, map_num::Integer, map_str::AbstractString; create_players = Catan.create_players)
+function do_tournament_one_map!(tourney::Tournament, configs, map_num::Integer, map_str::AbstractString; create_players = Catan.create_players)
     
     function log_games_per_map(map_num, tourney, i)
         g_num = (map_num - 1)*tourney.configs.games_per_map + i

--- a/src/tournaments.jl
+++ b/src/tournaments.jl
@@ -63,7 +63,7 @@ function do_tournament_one_epoch(tourney::AbstractTournament, configs; create_pl
     return finalize_epoch(tourney)
 end
 
-function do_tournament_one_map!(tourney::Tournament, configs, map_num::Integer; create_players = Catan.create_players)
+function do_tournament_one_map!(tourney::AbstractTournament, configs, map_num::Integer; create_players = Catan.create_players)
     map = Catan.generate_random_map()
     do_tournament_one_map!(tourney, configs, map_num, map; create_players)
 end


### PR DESCRIPTION
Create an `AbstractTournament` type that is implemented via
* Tournament
* AsyncTournament
* MutationTournament

to unify the mess of copy-pasted implementations in `tournaments.jl` by relying more on multiple dispatch to share code and clarify the logical flow.